### PR TITLE
Enable package validation to track public API compatibility

### DIFF
--- a/src/Pure.Primitives.DateTime.Operations/Pure.Primitives.DateTime.Operations.csproj
+++ b/src/Pure.Primitives.DateTime.Operations/Pure.Primitives.DateTime.Operations.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.4.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Primitives.DateTime.Operations</PackageId>


### PR DESCRIPTION
Closes #77

Add `EnablePackageValidation` and `PackageValidationBaselineVersion` to the project file so that breaking public API changes are detected during build/pack before publishing.